### PR TITLE
constant require + fs windows fix

### DIFF
--- a/wrapper.js
+++ b/wrapper.js
@@ -8,11 +8,11 @@
  * Licensed under the MIT license.
  */
 
-const cordova_lib = require('cordova-lib'),
-      _ = require('lodash'),
-      cordova = cordova_lib.cordova,
-      events = cordova_lib.events,
-      fs = require('fs');
+const cordova_lib = require('cordova-lib')
+const _ = require('lodash')
+const cordova = cordova_lib.cordova
+const events = cordova_lib.events
+const fs = require('fs')
 
 function cordovaWrapper(commandArray, next) {
 

--- a/wrapper.js
+++ b/wrapper.js
@@ -8,10 +8,10 @@
  * Licensed under the MIT license.
  */
 
-var cordova_lib = require('cordova-lib')
-var _ = require('lodash')
-var cordova = cordova_lib.cordova
-var events = cordova_lib.events
+const cordova_lib = require('cordova-lib'),
+      _ = require('lodash'),
+      cordova = cordova_lib.cordova,
+      events = cordova_lib.events;
 
 function cordovaWrapper(commandArray, next) {
 

--- a/wrapper.js
+++ b/wrapper.js
@@ -11,7 +11,8 @@
 const cordova_lib = require('cordova-lib'),
       _ = require('lodash'),
       cordova = cordova_lib.cordova,
-      events = cordova_lib.events;
+      events = cordova_lib.events,
+      fs = require('fs');
 
 function cordovaWrapper(commandArray, next) {
 


### PR DESCRIPTION
I changed the require statements to constants and added a fs require to fix an error occuring when I built for windows, this was missing but is used in the windows-code.